### PR TITLE
Reverting the Siddhi version to M106 and adding mkdocs for release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     </profiles>
 
     <properties>
-        <siddhi.version>4.0.0-M107</siddhi.version>
+        <siddhi.version>4.0.0-M106</siddhi.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.11</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
@@ -216,7 +216,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <configuration>
-                        <preparationGoals>clean install</preparationGoals>
+                        <preparationGoals>clean install -Pdocumentation-deploy</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Purpose
> Reverting the Siddhi dependency version to M106
> Add doc generation to release process

## Approach
> Updating the pom files with latest stable Siddhi version and included the mk-docs plugin for the release process.

## Automation tests
 - Unit tests 
   > 73%

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
